### PR TITLE
feat(component-model/validation): validate alias section (Trigger Actions)

### DIFF
--- a/include/common/enum.inc
+++ b/include/common/enum.inc
@@ -1084,6 +1084,8 @@ E(ArgTypeMismatch, 0x050D, "type mismatch")
 E(InvalidIndex, 0x050E, "invalid index")
 // Invalid Type Reference
 E(InvalidTypeReference, 0x050F, "invalid type reference")
+// Export Not Found
+E(ExportNotFound, 0x0510, "export not found")
 // @}
 
 // Component model instantiation phase

--- a/include/validator/context.h
+++ b/include/validator/context.h
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2019-2024 Second State INC
+#pragma once
+
 #include "ast/module.h"
 #include "common/errinfo.h"
 
+#include <deque>
 #include <optional>
 #include <unordered_map>
 #include <vector>
@@ -21,18 +24,52 @@ public:
     std::unordered_map<AST::Component::CoreSort, size_t> CoreIndexSizes;
     std::unordered_map<std::string, uint32_t> TypeSubstitutions;
 
+    std::unordered_map<uint32_t, std::unordered_map<std::string_view,
+                                                    AST::Component::ExternDesc>>
+        ComponentInstanceExports;
+    std::unordered_map<uint32_t,
+                       std::unordered_map<std::string_view, ExternalType>>
+        CoreInstanceExports;
+    std::unordered_map<uint32_t, AST::Component::InstanceType>
+        ComponentInstanceTypes;
+    std::unordered_map<uint32_t, AST::Component::ResourceType>
+        ComponentResourceTypes;
+
     ComponentContext(const AST::Component::Component *C,
                      std::optional<const ComponentContext *> P = std::nullopt)
         : Component(C), CoreModules(), ChildComponents(), Parent(P) {}
+
+    size_t getComponentIndexSize(AST::Component::SortCase SC) const noexcept {
+      auto It = ComponentIndexSizes.find(SC);
+      if (It != ComponentIndexSizes.end()) {
+        return It->second;
+      } else {
+        return 0;
+      }
+    }
+
+    size_t getCoreIndexSize(AST::Component::CoreSort CS) const noexcept {
+      auto It = CoreIndexSizes.find(CS);
+      if (It != CoreIndexSizes.end()) {
+        return It->second;
+      } else {
+        return 0;
+      }
+    }
   };
 
   void enterComponent(const AST::Component::Component &C) {
     if (!ComponentContexts.empty()) {
       ComponentContexts.back().ChildComponents.emplace_back(C);
     }
-    std::optional<const ComponentContext *> Parent =
-        ComponentContexts.empty() ? std::nullopt
-                                  : std::optional{&ComponentContexts.back()};
+
+    std::optional<const ComponentContext *> Parent;
+    if (ComponentContexts.empty()) {
+      Parent = std::nullopt;
+    } else {
+      Parent = std::optional{&ComponentContexts.back()};
+    }
+
     ComponentContexts.emplace_back(&C, Parent);
   }
 
@@ -71,19 +108,30 @@ public:
   }
 
   std::optional<const ComponentContext *> getParentContext() const {
-    return ComponentContexts.empty() ? std::nullopt
-                                     : ComponentContexts.back().Parent;
+    if (ComponentContexts.empty()) {
+      return std::nullopt;
+    }
+    return ComponentContexts.back().Parent;
   }
 
   size_t getComponentIndexSize(AST::Component::SortCase SC) const noexcept {
-    auto It = getCurrentContext().ComponentIndexSizes.find(SC);
-    return (It != getCurrentContext().ComponentIndexSizes.end()) ? It->second
-                                                                 : 0;
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.ComponentIndexSizes.find(SC);
+    if (It != Ctx.ComponentIndexSizes.end()) {
+      return It->second;
+    } else {
+      return 0;
+    }
   }
 
   size_t getCoreIndexSize(AST::Component::CoreSort CS) const noexcept {
-    auto It = getCurrentContext().CoreIndexSizes.find(CS);
-    return (It != getCurrentContext().CoreIndexSizes.end()) ? It->second : 0;
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.CoreIndexSizes.find(CS);
+    if (It != Ctx.CoreIndexSizes.end()) {
+      return It->second;
+    } else {
+      return 0;
+    }
   }
 
   void incComponentIndexSize(AST::Component::SortCase SC) noexcept {
@@ -100,15 +148,115 @@ public:
 
   std::optional<uint32_t>
   getSubstitutedType(const std::string &ImportName) const {
-    auto It = getCurrentContext().TypeSubstitutions.find(ImportName);
-    if (It != getCurrentContext().TypeSubstitutions.end()) {
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.TypeSubstitutions.find(ImportName);
+    if (It != Ctx.TypeSubstitutions.end()) {
       return It->second;
     }
     return std::nullopt;
   }
 
+  void addComponentInstanceExport(uint32_t InstanceIdx,
+                                  const std::string_view &ExportName,
+                                  const AST::Component::ExternDesc &ED) {
+    auto &Ctx = getCurrentContext();
+    Ctx.ComponentInstanceExports[InstanceIdx][ExportName] = ED;
+  }
+
+  std::unordered_map<std::string_view, AST::Component::ExternDesc>
+  getComponentInstanceExports(uint32_t InstanceIdx) const {
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.ComponentInstanceExports.find(InstanceIdx);
+    if (It != Ctx.ComponentInstanceExports.end()) {
+      return It->second;
+    }
+    return {};
+  }
+
+  size_t getComponentInstanceExportsSize() const {
+    const auto &Exports = getCurrentContext().ComponentInstanceExports;
+    if (Exports.empty()) {
+      return 0;
+    }
+
+    uint32_t MaxIdx = 0;
+    for (const auto &Pair : Exports) {
+      if (Pair.first > MaxIdx) {
+        MaxIdx = Pair.first;
+      }
+    }
+    return static_cast<size_t>(MaxIdx) + 1;
+  }
+
+  void addCoreInstanceExport(uint32_t InstanceIdx,
+                             const std::string_view &ExportName,
+                             const ExternalType &ET) {
+    auto &Ctx = getCurrentContext();
+    Ctx.CoreInstanceExports[InstanceIdx][ExportName] = ET;
+  }
+
+  std::unordered_map<std::string_view, ExternalType>
+  getCoreInstanceExports(uint32_t InstanceIdx) const {
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.CoreInstanceExports.find(InstanceIdx);
+    if (It != Ctx.CoreInstanceExports.end()) {
+      return It->second;
+    }
+    return {};
+  }
+
+  size_t getCoreInstanceExportsSize() const {
+    const auto &Exports = getCurrentContext().CoreInstanceExports;
+    if (Exports.empty()) {
+      return 0;
+    }
+
+    uint32_t MaxIdx = 0;
+    for (const auto &Pair : Exports) {
+      if (Pair.first > MaxIdx) {
+        MaxIdx = Pair.first;
+      }
+    }
+    return static_cast<size_t>(MaxIdx) + 1;
+  }
+
+  void addComponentInstanceType(uint32_t Idx,
+                                const AST::Component::InstanceType &IT) {
+    auto &Ctx = getCurrentContext();
+    Ctx.ComponentInstanceTypes[Idx] = IT;
+  }
+
+  const AST::Component::InstanceType *
+  getComponentInstanceType(uint32_t Idx) const {
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.ComponentInstanceTypes.find(Idx);
+    if (It != Ctx.ComponentInstanceTypes.end()) {
+      return &It->second;
+    } else {
+      return nullptr;
+    }
+  }
+
+  void addComponentResourceType(uint32_t Idx,
+                                const AST::Component::ResourceType &IT) {
+    auto &Ctx = getCurrentContext();
+    Ctx.ComponentResourceTypes[Idx] = IT;
+  }
+
+  const AST::Component::ResourceType *
+  getComponentResourceType(uint32_t Idx) const {
+    const auto &Ctx = getCurrentContext();
+    auto It = Ctx.ComponentResourceTypes.find(Idx);
+
+    if (It != Ctx.ComponentResourceTypes.end()) {
+      return &It->second;
+    } else {
+      return nullptr;
+    }
+  }
+
 private:
-  std::vector<ComponentContext> ComponentContexts;
+  std::deque<ComponentContext> ComponentContexts;
 };
 
 class ComponentContextGuard {

--- a/include/validator/validator.h
+++ b/include/validator/validator.h
@@ -16,6 +16,7 @@
 
 #include "ast/module.h"
 #include "common/configure.h"
+#include "validator/context.h"
 #include "validator/formchecker.h"
 
 #include <cstdint>
@@ -78,6 +79,8 @@ private:
   const Configure Conf;
   /// Formal checker
   FormChecker Checker;
+  /// Context for Component validation
+  Context Ctx;
 };
 
 } // namespace Validator

--- a/lib/loader/ast/component/component_type.cpp
+++ b/lib/loader/ast/component/component_type.cpp
@@ -284,7 +284,7 @@ Expect<void> Loader::loadType(FuncType &Ty) {
 Expect<void> Loader::loadType(InstanceType &Ty) {
   // instancetype  ::= 0x42 id*:vec(<instancedecl>)
   // => (instance id*)
-  return loadVec<TypeSection>(Ty.getContent(), [this](InstanceDecl Decl) {
+  return loadVec<TypeSection>(Ty.getContent(), [this](InstanceDecl &Decl) {
     return loadInstanceDecl(Decl);
   });
 }

--- a/lib/validator/validator_component.cpp
+++ b/lib/validator/validator_component.cpp
@@ -14,7 +14,6 @@ using namespace AST::Component;
 Expect<void> Validator::validate(const AST::Component::Component &Comp) {
   spdlog::warn("Component Model Validation is in active development."sv);
 
-  Context Ctx;
   ComponentContextGuard guard(Comp, Ctx);
   for (auto &Sec : Comp.getSections()) {
     EXPECTED_TRY(std::visit(SectionVisitor{*this, Ctx}, Sec));


### PR DESCRIPTION
* Validate alias core export, alias export and alias outer
* Move context initialization to validator.h
* Fix loader issue: switch to pass by reference
* Remove usage of ternary in context.h